### PR TITLE
add before first render hook

### DIFF
--- a/src/useBeforeFirstRender.ts
+++ b/src/useBeforeFirstRender.ts
@@ -1,0 +1,27 @@
+import { useEffect, useRef } from 'react';
+
+/**
+ * Executes a callback before first render of a component
+ *
+ * @param callback Method to execute.
+ *
+ * @example
+ * function Example() {
+ *   useBeforeFirstRender(() => {
+ *     // Custom logic to execute each second
+ *   });
+ *   // ...
+ * }
+ */
+
+export default function useBeforeFirstRender(callback: () => void) {
+  const hasRendered = useRef(false);
+
+  useEffect(() => {
+    hasRendered.current = true;
+  }, []);
+
+  if (!hasRendered.current) {
+    callback();
+  }
+}


### PR DESCRIPTION
Created this hook when i was trying to implement a router package for react. Takes in a callback as a param and runs the callback before first render only.

Created this pr to discuss the hook and if it is actually usable or too straight forward. Also couldn't come up with a simple use case example for this.