### PR TITLE
[WIP] Rewrite as wrapper hook

### DIFF
--- a/src/ssr.test.tsx
+++ b/src/ssr.test.tsx
@@ -34,6 +34,7 @@ test.each(
     useSessionStorage: () => hooks.useSessionStorage('foo'),
     useTimeline: () => hooks.useTimeline(0),
     useUndoable: () => hooks.useUndoable(useState()),
+    useToggle: () => hooks.useToggle(useState(false as boolean)),
   }),
 )('%s supports SSR', (_name, callback) => {
   renderHookToString(callback);

--- a/src/ssr.test.tsx
+++ b/src/ssr.test.tsx
@@ -34,7 +34,7 @@ test.each(
     useSessionStorage: () => hooks.useSessionStorage('foo'),
     useTimeline: () => hooks.useTimeline(0),
     useUndoable: () => hooks.useUndoable(useState()),
-    useToggle: () => hooks.useToggle(useState(false as boolean)),
+    useToggle: () => hooks.useToggle(useState(false)),
   }),
 )('%s supports SSR', (_name, callback) => {
   renderHookToString(callback);

--- a/src/useToggle.test.ts
+++ b/src/useToggle.test.ts
@@ -1,35 +1,33 @@
-import { useState } from 'react';
 import { act, renderHook } from '@testing-library/react-hooks';
+import { useState } from 'react';
 import { useToggle } from '.';
 
 test('negate toggle state', () => {
-  const { result: stateResult } = renderHook(() => useState(false));
-  const { result } = renderHook(() => useToggle(stateResult.current));
+  const { result } = renderHook(() => useToggle(useState(false)));
   expect(result.current[0]).toBe(false);
 
   act(() => {
     result.current[2]();
   });
-  expect(stateResult.current[0]).toBe(true);
+  expect(result.current[0]).toBe(true);
 
   act(() => {
     result.current[2]();
   });
-  expect(stateResult.current[0]).toBe(false);
+  expect(result.current[0]).toBe(false);
 });
 
 test('set toggle state', () => {
-  const { result: stateResult } = renderHook(() => useState(true));
-  const { result } = renderHook(() => useToggle(stateResult.current));
+  const { result } = renderHook(() => useToggle(useState(true)));
   expect(result.current[0]).toBe(true);
 
   act(() => {
     result.current[1](true);
   });
-  expect(stateResult.current[0]).toBe(true);
+  expect(result.current[0]).toBe(true);
 
   act(() => {
     result.current[1](false);
   });
-  expect(stateResult.current[0]).toBe(false);
+  expect(result.current[0]).toBe(false);
 });

--- a/src/useToggle.test.ts
+++ b/src/useToggle.test.ts
@@ -1,32 +1,35 @@
+import { useState } from 'react';
 import { act, renderHook } from '@testing-library/react-hooks';
 import { useToggle } from '.';
 
 test('negate toggle state', () => {
-  const { result } = renderHook(() => useToggle());
+  const { result: stateResult } = renderHook(() => useState(false));
+  const { result } = renderHook(() => useToggle(stateResult.current));
   expect(result.current[0]).toBe(false);
 
   act(() => {
-    result.current[1]();
+    result.current[2]();
   });
-  expect(result.current[0]).toBe(true);
+  expect(stateResult.current[0]).toBe(true);
 
   act(() => {
-    result.current[1]();
+    result.current[2]();
   });
-  expect(result.current[0]).toBe(false);
+  expect(stateResult.current[0]).toBe(false);
 });
 
 test('set toggle state', () => {
-  const { result } = renderHook(() => useToggle(true));
+  const { result: stateResult } = renderHook(() => useState(true));
+  const { result } = renderHook(() => useToggle(stateResult.current));
   expect(result.current[0]).toBe(true);
 
   act(() => {
     result.current[1](true);
   });
-  expect(result.current[0]).toBe(true);
+  expect(stateResult.current[0]).toBe(true);
 
   act(() => {
     result.current[1](false);
   });
-  expect(result.current[0]).toBe(false);
+  expect(stateResult.current[0]).toBe(false);
 });

--- a/src/useToggle.ts
+++ b/src/useToggle.ts
@@ -3,12 +3,12 @@ import { useCallback } from 'react';
 /* eslint-disable jsdoc/valid-types */
 
 /**
- * Tracks state of a boolean value.
+ * Wraps a state hook to add boolean toggle functionality.
  *
- * @see [`useState` hook](https://reactjs.org/docs/hooks-reference.html#usestate), which exposes a similar interface
- *
- * @param {boolean} initialValue Initial value.
- * @returns {[boolean, function (nextValue: boolean?): void]} A statefully stored value, and a function to update it. The latter may be called without a boolean argument to negate the value.
+ * @param useStateResult Return value of a state hook.
+ * @param useStateResult.0 Current state.
+ * @param useStateResult.1 State updater function.
+ * @returns State hook result extended with a `toggle` function.
  *
  * @example
  * function Example() {
@@ -28,6 +28,5 @@ export default function useToggle([value, setValue]: [
   const toggleValue = useCallback(() => {
     setValue(prevValue => !prevValue);
   }, [setValue]);
-
   return [value, setValue, toggleValue];
 }

--- a/src/useToggle.ts
+++ b/src/useToggle.ts
@@ -1,4 +1,4 @@
-import { useCallback, useState } from 'react';
+import { useCallback } from 'react';
 
 /* eslint-disable jsdoc/valid-types */
 
@@ -21,18 +21,13 @@ import { useCallback, useState } from 'react';
  *   );
  * }
  */
-export default function useToggle(
-  initialValue = false,
-): [boolean, (nextValue?: unknown) => void] {
-  const [value, setValue] = useState(initialValue);
+export default function useToggle([value, setValue]: [
+  boolean,
+  React.Dispatch<React.SetStateAction<boolean>>,
+]): [boolean, React.Dispatch<React.SetStateAction<boolean>>, () => void] {
+  const toggleValue = useCallback(() => {
+    setValue(prevValue => !prevValue);
+  }, [setValue]);
 
-  const toggleValue = useCallback((nextValue?: unknown) => {
-    if (typeof nextValue === 'boolean') {
-      setValue(nextValue);
-    } else {
-      setValue(prevValue => !prevValue);
-    }
-  }, []);
-
-  return [value, toggleValue];
+  return [value, setValue, toggleValue];
 }


### PR DESCRIPTION
Rewrote the useToggle as a wrapper hook. However, I believe the user may want to use the old interface. Would it be a good idea to create another hook similar to useLocalStorage? 

If you think the implementation is good I can proceed to update the file documentation accordingly.

Issue #36 